### PR TITLE
Luna's Howl (Addition)

### DIFF
--- a/Tchailenova's D2 Wishlist Content
+++ b/Tchailenova's D2 Wishlist Content
@@ -79,6 +79,10 @@ Koraxis's Distress (Strand Heavy Grenade Launcher)
 dimwishlist:item=2972949637&perks=3798852852,332133599,968510818,3215448563,3186078099#notes: probably pretty good for non-boss engagements (The Vault of LW, etc.). works best with rufus' fury and another harmonic energy weapon. tags: #pve
 
 
+Luna's Howl (Solar Hand Cannon)
+dimwishlist:item=2763843899&perks=1840239774,3230963543,1195158366,2720533289#notes: Very Stable. Optimized for sets of precision kills and a solid damage buff once it gets rolling. tags: #pve
+
+
 Path of Least Resistance (Arc Trace Rifle)
 dimwishlist:item=2827764482&perks=1840239774,732557052,1583705720,4049631843,2839173408#notes: fantastically max-statted when fully activated. tags: #pve
 


### PR DESCRIPTION
Add godroll for Luna's Howl, solar hand cannon in Brave Arsenal weapon-set.